### PR TITLE
Add dedicated cart page with navigation and full-width products

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import { ShoppingCart } from "lucide-react";
+
+interface HeaderProps {
+  cartItemCount: number;
+}
+
+export const Header = ({ cartItemCount }: HeaderProps) => (
+  <header className="bg-card border-b border-border">
+    <div className="container mx-auto px-4 py-6 flex items-center justify-between">
+      <Link to="/" className="text-foreground">
+        <h1 className="text-3xl font-bold">Team Merch Store</h1>
+        <p className="text-muted-foreground text-sm">
+          Limited edition team merchandise - Order your items below
+        </p>
+      </Link>
+      <Link to="/cart" className="flex items-center gap-2 text-foreground">
+        <ShoppingCart className="h-5 w-5" />
+        <span>Cart{cartItemCount > 0 && ` (${cartItemCount})`}</span>
+      </Link>
+    </div>
+  </header>
+);

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,0 +1,39 @@
+export interface Product {
+  id: string;
+  name: string;
+  price: number;
+  description?: string;
+}
+
+export const PRODUCTS: Product[] = [
+  {
+    id: "hoodies",
+    name: "Hoodies",
+    price: 35.23,
+    description: "Comfortable team hoodies with company logo"
+  },
+  {
+    id: "quarter-zips",
+    name: "Quarter Zips",
+    price: 31.37,
+    description: "Professional quarter-zip pullovers"
+  },
+  {
+    id: "tshirts",
+    name: "T-Shirts",
+    price: 8.44,
+    description: "Classic team t-shirts"
+  },
+  {
+    id: "polo-shirts",
+    name: "Polo Shirts",
+    price: 17.23,
+    description: "Business casual polo shirts"
+  },
+  {
+    id: "stickers",
+    name: "Stickers",
+    price: 0,
+    description: "Free company logo stickers"
+  }
+];

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,0 +1,34 @@
+import { CartSummary } from "@/components/CartSummary";
+import { OrderConfirmation } from "@/components/OrderConfirmation";
+
+interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface CartPageProps {
+  items: CartItem[];
+  onCheckout: () => void;
+  orderPlaced: string | null;
+  resetToShopping: () => void;
+}
+
+const Cart = ({ items, onCheckout, orderPlaced, resetToShopping }: CartPageProps) => {
+  if (orderPlaced) {
+    return (
+      <OrderConfirmation orderNumber={orderPlaced} onBackToShopping={resetToShopping} />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 py-8">
+        <CartSummary items={items} onCheckout={onCheckout} />
+      </main>
+    </div>
+  );
+};
+
+export default Cart;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,167 +1,26 @@
-import { useState } from "react";
 import { ProductCard } from "@/components/ProductCard";
-import { CartSummary } from "@/components/CartSummary";
-import { OrderConfirmation } from "@/components/OrderConfirmation";
-import { useToast } from "@/hooks/use-toast";
+import { PRODUCTS } from "@/lib/products";
 
-interface Product {
-  id: string;
-  name: string;
-  price: number;
-  description?: string;
+interface IndexProps {
+  cart: Record<string, number>;
+  addToCart: (productId: string) => void;
+  updateQuantity: (productId: string, quantity: number) => void;
 }
 
-interface CartItem extends Product {
-  quantity: number;
-}
-
-const PRODUCTS: Product[] = [
-  {
-    id: "hoodies",
-    name: "Hoodies",
-    price: 35.23,
-    description: "Comfortable team hoodies with company logo"
-  },
-  {
-    id: "quarter-zips",
-    name: "Quarter Zips",
-    price: 31.37,
-    description: "Professional quarter-zip pullovers"
-  },
-  {
-    id: "tshirts",
-    name: "T-Shirts",
-    price: 8.44,
-    description: "Classic team t-shirts"
-  },
-  {
-    id: "polo-shirts",
-    name: "Polo Shirts",
-    price: 17.23,
-    description: "Business casual polo shirts"
-  },
-  {
-    id: "stickers",
-    name: "Stickers",
-    price: 0,
-    description: "Free company logo stickers"
-  }
-];
-
-const Index = () => {
-  const [cart, setCart] = useState<Record<string, number>>({});
-  const [orderPlaced, setOrderPlaced] = useState<string | null>(null);
-  const { toast } = useToast();
-
-  const addToCart = (productId: string) => {
-    setCart(prev => ({
-      ...prev,
-      [productId]: (prev[productId] || 0) + 1
-    }));
-    toast({
-      title: "Added to cart",
-      description: "Item has been added to your order",
-    });
-  };
-
-  const updateQuantity = (productId: string, quantity: number) => {
-    if (quantity === 0) {
-      setCart(prev => {
-        const newCart = { ...prev };
-        delete newCart[productId];
-        return newCart;
-      });
-    } else {
-      setCart(prev => ({
-        ...prev,
-        [productId]: quantity
-      }));
-    }
-  };
-
-  const getCartItems = (): CartItem[] => {
-    return Object.entries(cart)
-      .map(([productId, quantity]) => {
-        const product = PRODUCTS.find(p => p.id === productId);
-        return product ? { ...product, quantity } : null;
-      })
-      .filter((item): item is CartItem => item !== null);
-  };
-
-  const handleCheckout = () => {
-    // Generate a simple order number
-    const orderNumber = `ORD-${Date.now().toString().slice(-6)}`;
-    
-    // In a real app, this would submit to your database
-    console.log("Order placed:", {
-      orderNumber,
-      items: getCartItems(),
-      timestamp: new Date().toISOString()
-    });
-    
-    setOrderPlaced(orderNumber);
-    setCart({});
-    
-    toast({
-      title: "Order placed successfully!",
-      description: `Order ${orderNumber} has been submitted for review.`,
-    });
-  };
-
-  const resetToShopping = () => {
-    setOrderPlaced(null);
-  };
-
-  if (orderPlaced) {
-    return (
-      <OrderConfirmation 
-        orderNumber={orderPlaced}
-        onBackToShopping={resetToShopping}
-      />
-    );
-  }
-
+const Index = ({ cart, addToCart, updateQuantity }: IndexProps) => {
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="bg-card border-b border-border">
-        <div className="container mx-auto px-4 py-6">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold text-foreground mb-2">
-              Team Merch Store
-            </h1>
-            <p className="text-muted-foreground">
-              Limited edition team merchandise - Order your items below
-            </p>
-          </div>
-        </div>
-      </header>
-
-      {/* Main Content */}
       <main className="container mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* Products Grid */}
-          <div className="lg:col-span-2">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {PRODUCTS.map((product) => (
-                <ProductCard
-                  key={product.id}
-                  product={product}
-                  quantity={cart[product.id] || 0}
-                  onAddToCart={addToCart}
-                  onUpdateQuantity={updateQuantity}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Cart Summary */}
-          <div className="lg:col-span-1">
-            <CartSummary 
-              items={getCartItems()}
-              onCheckout={handleCheckout}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {PRODUCTS.map((product) => (
+            <ProductCard
+              key={product.id}
+              product={product}
+              quantity={cart[product.id] || 0}
+              onAddToCart={addToCart}
+              onUpdateQuantity={updateQuantity}
             />
-          </div>
+          ))}
         </div>
       </main>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -96,5 +97,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Move cart summary into new `/cart` page and manage cart state in `App`.
- Add a site-wide header with navigation link and item count for the cart.
- Expand product listing into a full-width responsive grid and share product data.
- Fix lint errors in UI utilities and update tailwind config to use ESM plugin import.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b63166221c83248080382436069c2a