### PR TITLE
feat: add admin view for order management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Cart from "./pages/Cart";
+import Admin from "./pages/Admin";
 import { Header } from "@/components/Header";
 import { PRODUCTS, Product } from "@/lib/products";
 import { useToast } from "@/hooks/use-toast";
@@ -15,6 +16,12 @@ const queryClient = new QueryClient();
 
 interface CartItem extends Product {
   quantity: number;
+}
+
+interface Order {
+  orderNumber: string;
+  items: CartItem[];
+  timestamp: string;
 }
 
 const App = () => {
@@ -55,11 +62,14 @@ const App = () => {
 
   const handleCheckout = () => {
     const orderNumber = `ORD-${Date.now().toString().slice(-6)}`;
-    console.log("Order placed:", {
+    const newOrder: Order = {
       orderNumber,
       items: getCartItems(),
       timestamp: new Date().toISOString()
-    });
+    };
+    const existingOrders: Order[] = JSON.parse(localStorage.getItem('orders') || '[]');
+    localStorage.setItem('orders', JSON.stringify([...existingOrders, newOrder]));
+    console.log("Order placed:", newOrder);
     setOrderPlaced(orderNumber);
     setCart({});
     toast({
@@ -84,6 +94,7 @@ const App = () => {
           <Routes>
             <Route path="/" element={<Index cart={cart} addToCart={addToCart} updateQuantity={updateQuantity} />} />
             <Route path="/cart" element={<Cart items={getCartItems()} onCheckout={handleCheckout} orderPlaced={orderPlaced} resetToShopping={resetToShopping} />} />
+            <Route path="/admin" element={<Admin />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,10 +14,15 @@ export const Header = ({ cartItemCount }: HeaderProps) => (
           Limited edition team merchandise - Order your items below
         </p>
       </Link>
-      <Link to="/cart" className="flex items-center gap-2 text-foreground">
-        <ShoppingCart className="h-5 w-5" />
-        <span>Cart{cartItemCount > 0 && ` (${cartItemCount})`}</span>
-      </Link>
+      <div className="flex items-center gap-4 text-foreground">
+        <Link to="/admin" className="hover:underline">
+          Admin
+        </Link>
+        <Link to="/cart" className="flex items-center gap-2">
+          <ShoppingCart className="h-5 w-5" />
+          <span>Cart{cartItemCount > 0 && ` (${cartItemCount})`}</span>
+        </Link>
+      </div>
     </div>
   </header>
 );

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+
+interface OrderItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface Order {
+  orderNumber: string;
+  items: OrderItem[];
+  timestamp: string;
+}
+
+const ADMIN_PASSWORD = "admin";
+
+const Admin = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(() => localStorage.getItem("adminAuthenticated") === "true");
+  const [password, setPassword] = useState("");
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      const stored: Order[] = JSON.parse(localStorage.getItem("orders") || "[]");
+      setOrders(stored);
+    }
+  }, [isLoggedIn]);
+
+  const handleLogin = () => {
+    if (password === ADMIN_PASSWORD) {
+      localStorage.setItem("adminAuthenticated", "true");
+      setIsLoggedIn(true);
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem("adminAuthenticated");
+    setIsLoggedIn(false);
+  };
+
+  if (!isLoggedIn) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Card className="w-full max-w-sm">
+          <CardHeader>
+            <CardTitle>Admin Login</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+            />
+            <Button className="w-full" onClick={handleLogin}>
+              Login
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen p-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Orders</CardTitle>
+          <Button variant="outline" onClick={handleLogout}>
+            Logout
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {orders.length === 0 ? (
+            <p className="text-muted-foreground">No orders placed yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Order #</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Items</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {orders.map(order => (
+                  <TableRow key={order.orderNumber}>
+                    <TableCell>{order.orderNumber}</TableCell>
+                    <TableCell>{new Date(order.timestamp).toLocaleString()}</TableCell>
+                    <TableCell>
+                      <ul className="list-disc pl-4 space-y-1">
+                        {order.items.map(item => (
+                          <li key={item.id}>
+                            {item.name} x {item.quantity}
+                          </li>
+                        ))}
+                      </ul>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Admin;
+


### PR DESCRIPTION
## Summary
- persist orders to localStorage and expose new admin route
- add admin login page to review orders
- link admin view from header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6494d0f9083248637c3ebc2e32ad9