### PR TITLE
fix: remove global border style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -106,10 +106,6 @@ All colors MUST be HSL.
 }
 
 @layer base {
-  * {
-    @apply border-border;
-  }
-
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary
- remove global `*` border color rule to eliminate yellow outlines

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b78c0558cc832495c094ff51ff5f2d