### PR TITLE
Use dark blue borders for store components

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ interface HeaderProps {
 }
 
 export const Header = ({ cartItemCount }: HeaderProps) => (
-  <header className="bg-card border-b border-border">
+  <header className="bg-card border-b border-primary">
     <div className="container mx-auto px-4 py-6 flex items-center justify-between">
       <Link to="/" className="text-foreground">
         <h1 className="text-3xl font-bold">Team Merch Store</h1>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -18,7 +18,7 @@ export const ProductCard = ({ product, quantity, onAddToCart, onUpdateQuantity }
   };
 
   return (
-    <Card className="group hover:shadow-[var(--shadow-hover)] transition-[var(--transition-smooth)] bg-[var(--gradient-card)] border-border overflow-hidden">
+    <Card className="group hover:shadow-[var(--shadow-hover)] transition-[var(--transition-smooth)] bg-[var(--gradient-card)] border-primary overflow-hidden">
       <CardHeader className="pb-4">
         <div className="aspect-square rounded-lg mb-4 overflow-hidden bg-muted">
           {product.image ? (


### PR DESCRIPTION
## Summary
- switch product card borders to dark blue primary color
- update store header to use matching dark blue border

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7aeb01e8c832489174b1f5b7d9e92